### PR TITLE
Make glucose measurement context optional (UPLOAD-783)

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,13 +107,17 @@ export default class bluetoothLE extends EventTarget {
 
       this.glucoseMeasurement = await this.glucoseService.getCharacteristic('glucose_measurement');
       await this.glucoseMeasurement.startNotifications();
-      this.glucoseMeasurementContext = await this.glucoseService.getCharacteristic('glucose_measurement_context');
-      await this.glucoseMeasurementContext.startNotifications();
+      try {
+        this.glucoseMeasurementContext = await this.glucoseService.getCharacteristic('glucose_measurement_context');
+        await this.glucoseMeasurementContext.startNotifications();
+        this.glucoseMeasurementContext.addEventListener('characteristicvaluechanged', bluetoothLE.handleContextNotifications);
+      } catch (err) {
+        console.log(err);
+      }
       this.racp = await this.glucoseService.getCharacteristic('record_access_control_point');
       await this.racp.startNotifications();
       debug('Notifications started.');
 
-      this.glucoseMeasurementContext.addEventListener('characteristicvaluechanged', bluetoothLE.handleContextNotifications);
       this.glucoseMeasurement.addEventListener('characteristicvaluechanged', this.handleNotifications);
       this.racp.addEventListener('characteristicvaluechanged', this.handleRACP);
       debug('Event listeners added.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ble-glucose",
-  "version": "0.3.0",
+  "version": "0.3.0-optional-context.1",
   "description": "Reads blood glucose values from Bluetooth LE enabled meters",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is part of [UPLOAD-783]. Fora meters don't support glucose measurement context, so we have to make it optional. Note that this is currently based against `only-use-eventtarget` as that work is not merged yet.